### PR TITLE
Added the current search context frame as field to WebElementDefinition,...

### DIFF
--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainPresenter.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainPresenter.cs
@@ -141,11 +141,41 @@ namespace SwdPageRecorder.UI
             {
                 var addElementCommand = command as AddElement;
 
+                SimpleFrame simpleFrame;
+                BrowserPageFrame browserPageFrame = view.getCurrentlyChosenFrame();
+                if (browserPageFrame != null)
+                {
+                    List<string> childs = new List<string>();
+                    string parentTitle;
+                    if (browserPageFrame.ParentFrame != null)
+                    {
+                        parentTitle = browserPageFrame.ParentFrame.GetTitle();
+                    }
+                    else
+                    {
+                        parentTitle = "none";
+                    }
+                    if (browserPageFrame.ChildFrames != null)
+                    {
+                        foreach (BrowserPageFrame b in browserPageFrame.ChildFrames)
+                        {
+                            childs.Add(b.GetTitle());
+                        }
+                    }
+
+                    simpleFrame = new SimpleFrame(browserPageFrame.Index, browserPageFrame.LocatorNameOrId, browserPageFrame.GetTitle(), parentTitle, childs);
+                }
+                else
+                {
+                    simpleFrame = new SimpleFrame(-1, "noFrameChosen", "noFrameChosen", "noFrameChosen", null);
+                }
+
                 var element = new WebElementDefinition()
                 {
                     Name = addElementCommand.ElementCodeName,
                     HowToSearch = LocatorSearchMethod.XPath,
                     Locator = addElementCommand.ElementXPath,
+                    frame = simpleFrame,
                 };
                 bool addNew = true;
                 Presenters.SelectorsEditPresenter.UpdateWebElementWithAdditionalProperties(element);

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.cs
@@ -68,6 +68,23 @@ namespace SwdPageRecorder.UI
             }
         }
 
+        public BrowserPageFrame getCurrentlyChosenFrame()
+        {
+            BrowserPageFrame frame = null;
+            object item = null;
+            this.ddlFrames.Invoke((MethodInvoker)delegate()
+            {
+                item = ddlFrames.SelectedItem;
+            }
+            );
+            if (item is BrowserPageFrame)
+            {
+                frame = item as BrowserPageFrame;
+
+            }
+            return frame;
+        }
+
         private void btnBrowser_Go_Click(object sender, EventArgs e)
         {
             presenter.SetBrowserUrl(txtBrowserUrl.Text);

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/SimpleFrame.cs
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/SimpleFrame.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SwdPageRecorder.WebDriver
+{
+    public class SimpleFrame
+    {
+        public int Index { get; set; }
+        public string LocatorNameOrId { get; set; }
+        public string Title { get; set; }
+
+        public string ParentFrame { get; set; }
+        public List<string> ChildFrames { get; set; }
+
+        public SimpleFrame()
+        {
+        }
+
+        public SimpleFrame(int index, string loc, string title, string parent, List<string> childs)
+        {
+            this.Index = index;
+            this.LocatorNameOrId = loc;
+            this.Title = title;
+            this.ParentFrame = parent;
+            this.ChildFrames = childs;
+        }
+
+        public override string ToString()
+        {
+            return Title;
+        }
+    }
+}

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/SwdPageRecorder.WebDriver.csproj
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/SwdPageRecorder.WebDriver.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SeleniumServerProcess.cs" />
     <Compile Include="SerializableDictionary.cs" />
+    <Compile Include="SimpleFrame.cs" />
     <Compile Include="SwdBrowser.cs" />
     <Compile Include="SwdBrowserUtils\BrowserCommands.cs" />
     <Compile Include="SwdBrowserUtils\ElementAttributesList.cs" />

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/WebElementDefinition.cs
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/WebElementDefinition.cs
@@ -41,6 +41,8 @@ namespace SwdPageRecorder.WebDriver
         [Browsable(false)]
         public string Arg3 { get; set; }
 
+        [DisplayName("Frame")]
+        public SimpleFrame frame { get; set; }
 
         public WebElementDefinition()
         {
@@ -97,6 +99,7 @@ namespace SwdPageRecorder.WebDriver
                 Arg3 = Arg3,
                 AllHtmlTagProperties = new WebElementHtmlAttributes(),
                 AlternativeFindBys = null,
+                frame = frame,
             };
 
 


### PR DESCRIPTION
... so that it can be accessed in templates.

Hi Dmytro,
as you suggested in the google group, i submit this pull request (i was Horst there). Please check if you would be ok with this addition. Feel free to change anything ;)

I'll quote myself on this:
"I started doing a modification myself and added the Frame to the WebElementDefinition class (i had to use a new class [SimpleFrame], because i ran into a cycle at serialization). When an element is created, i simply fill the frame with that one, that is selected in the tool as search context. This should work in general, because you can only detect elements in the frame that you have selected anyway.
The reason i do this is because i need to access the frame in my template for code generation. I'm going for a class in my test code, that gets a locator and the containing frame (as string) - this way, the element will be able to switch into that frame automatically when an action is called, so that i can ignore the whole frame issue (i'll add a decorator that does the switching)."

This comes from project experience, where it is annoying to constantly switch between frames. I concluded it would be best, to let this be done by a WebElement Wrapper Class.
I commited from this branch, because the master was not building for me with an indiscernable error saying only "the file contains damaged data".

Best Wishes,
Rongo