### PR TITLE
polished some minor things in the tool

### DIFF
--- a/SwdPageRecorder/SwdPageRecorder.TestModel/SwdPageRecorder.TestModel.csproj
+++ b/SwdPageRecorder/SwdPageRecorder.TestModel/SwdPageRecorder.TestModel.csproj
@@ -61,8 +61,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\TestStack.White.0.13.3\lib\net40\TestStack.White.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver, Version=2.51.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.51.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.53.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.53.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/SwdPageRecorder/SwdPageRecorder.TestModel/packages.config
+++ b/SwdPageRecorder/SwdPageRecorder.TestModel/packages.config
@@ -3,6 +3,6 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.51.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.53.0" targetFramework="net45" />
   <package id="TestStack.White" version="0.13.3" targetFramework="net45" />
 </packages>

--- a/SwdPageRecorder/SwdPageRecorder.Tests/SwdPageRecorder.Tests.csproj
+++ b/SwdPageRecorder/SwdPageRecorder.Tests/SwdPageRecorder.Tests.csproj
@@ -92,8 +92,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\TestStack.White.0.13.3\lib\net40\TestStack.White.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver, Version=2.51.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.51.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.53.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.53.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/SwdPageRecorder/SwdPageRecorder.Tests/packages.config
+++ b/SwdPageRecorder/SwdPageRecorder.Tests/packages.config
@@ -5,6 +5,6 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
   <package id="NUnitTestAdapter.WithFramework" version="2.0.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.51.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.53.0" targetFramework="net45" />
   <package id="TestStack.White" version="0.13.3" targetFramework="net45" />
 </packages>

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainPresenter.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainPresenter.cs
@@ -200,11 +200,14 @@ namespace SwdPageRecorder.UI
                     simpleFrame = new SimpleFrame(-1, "noFrameChosen", "noFrameChosen", "noFrameChosen", null);
                 }
 
+                bool emptyHtmlId = String.IsNullOrEmpty(addElementCommand.ElementId);
                 var element = new WebElementDefinition()
                 {
                     Name = addElementCommand.ElementCodeName,
-                    HowToSearch = LocatorSearchMethod.XPath,
-                    Locator = addElementCommand.ElementXPath,
+                    HtmlId = addElementCommand.ElementId,
+                    Xpath = addElementCommand.ElementXPath,
+                    HowToSearch = (emptyHtmlId) ? LocatorSearchMethod.XPath: LocatorSearchMethod.Id,
+                    Locator = (emptyHtmlId) ? addElementCommand.ElementXPath: addElementCommand.ElementId,
                     CssSelector = addElementCommand.ElementCssSelector,
                     frame = simpleFrame,
                 };

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.Designer.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.Designer.cs
@@ -34,6 +34,7 @@
             this.btnOpenBrowserPreview = new System.Windows.Forms.Button();
             this.btnOpenScreenshotFolder = new System.Windows.Forms.Button();
             this.btnTakePageScreenshot = new System.Windows.Forms.Button();
+            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.btnBrowser_Go = new System.Windows.Forms.Button();
             this.txtBrowserUrl = new System.Windows.Forms.TextBox();
             this.pnlLoadingBar = new System.Windows.Forms.Panel();
@@ -70,7 +71,6 @@
             this.tabPage6 = new System.Windows.Forms.TabPage();
             this.playGroundView1 = new SwdPageRecorder.UI.PlayGroundView();
             this.pageObjectDefinitionView = new SwdPageRecorder.UI.PageObjectDefinitionView();
-            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.groupBox1.SuspendLayout();
             this.pnlLoadingBar.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
@@ -140,6 +140,18 @@
             this.btnTakePageScreenshot.TabIndex = 3;
             this.btnTakePageScreenshot.UseVisualStyleBackColor = true;
             this.btnTakePageScreenshot.Click += new System.EventHandler(this.btnTakePageScreenshot_Click);
+            // 
+            // linkLabel1
+            // 
+            this.linkLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.linkLabel1.AutoSize = true;
+            this.linkLabel1.Location = new System.Drawing.Point(868, 18);
+            this.linkLabel1.Name = "linkLabel1";
+            this.linkLabel1.Size = new System.Drawing.Size(116, 13);
+            this.linkLabel1.TabIndex = 2;
+            this.linkLabel1.TabStop = true;
+            this.linkLabel1.Text = "Visit project\'s home site";
+            this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
             // 
             // btnBrowser_Go
             // 
@@ -535,18 +547,6 @@
             this.pageObjectDefinitionView.Name = "pageObjectDefinitionView";
             this.pageObjectDefinitionView.Size = new System.Drawing.Size(244, 420);
             this.pageObjectDefinitionView.TabIndex = 2;
-            // 
-            // linkLabel1
-            // 
-            this.linkLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(868, 18);
-            this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(116, 13);
-            this.linkLabel1.TabIndex = 2;
-            this.linkLabel1.TabStop = true;
-            this.linkLabel1.Text = "Visit project\'s home site";
-            this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
             // 
             // SwdMainView
             // 

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.resx
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/SwdMainView.resx
@@ -123,29 +123,31 @@
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABUAAAAYCAIAAACa6yEfAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAARLSURBVDhPhdJ7TFpXHAfwsyxZsixZsizZmrRpVayCUhAF
-        8QnamqZLk3bLkjVdsu2P7Y+tyUyWJqUtW9dNXevbivjgcUFBUFSU1ke3uU5d5wNctMps4wsfSIvK4wIX
-        Llpzd8CrVtdlJ9+Qc87v++EkBPBAIvjf/FZ3MLsj0CcVEC4BQZT9V7a2SjY3i4PBIhwPBW7gEV6GpoPn
-        wIBMYCp7J9ib89IEfjnlu3/S1Zlt7+Db2ngwcOO8l+3tOQlHys9B2Be/Hfw5+9/B72f5uviODh46Kdvw
-        WDewVXShb1abY21Odxp4cKT4DICHcoGp8K0Q6OGHsrvp4fs7eaghE30kJl5Ylt7vp5XcZ7o0jyET+QSA
-        ISTsd8yLwTp5zvYM9LGWpASxEUBNivNmGceqTXV3ZOz4n94MdmaEDPzcCX4vHTOkO1pSF7XZK8NVK+Mt
-        MwM1/VU5f5Yx/5YkrTRyUX0a8jEAIwqBKe+NoCH1QALtKd5W7ro2eUGRNCFOGCw50Xeb/rCYPiZizskT
-        VzUcOFVceJnHO1L8+hRfG9elS36qZsM29KYKhrGcAfG0NNGmYsMR7JDe+MPreDt3O/62ZF9rMtrCXdOw
-        rfWJi/qL9lEZumxyL5nG5WcmqxgWOQuOPDoObCo+AsCk3PPwytvCcTVxnjVy1/pv+Fcfk79beD3p+na8
-        krGAsNY1bPhGQB/2f9WTHp7hraspzTNatumzb2BrpNtZ/aKzxpK4uTrGuorla07CW9mKDwEYaxAYb7wG
-        D35dEtb7xabbgj5CZlTvDRXRcO/eVzht0/orUYO3Ymer49frGZg2AW9mKd4HYEIlMApfhQe/NgHVsNfU
-        aQt19MlymlF8mqThNaARQj98O9ZSS3c2MPf7a69se08jc03JWKyjmytoS0MISQnC516V58Z0CiljpdRl
-        Kd2tYsLyfq9lBjQMn5rhVJ5YroufqmQ9D2Kkho/rCtS5xx7cjJ6qoNrldK+KAcuQKM4BYFYLjFcArqbD
-        YA3xLiRuuZpq+72QpAQRDGDyr2n6y0eH8ynzoliHLA7WtvuKswBMNe7zcGwRUXG3ldQEMdmnkX95uPtq
-        xHhh9JKYCh846Ecug0B9nB+J8SI0e22s1fAVScOrOe98w6XDv14/NlFIWRLFOCRUWPMraZAgZwB4ohWM
-        fAMCiljoUWmMrSraZe4gKUFsbT2/8+m77UL2dHd+YH3uqe7CavVxWMPkMZAgp3e9LBp6t+T4cnkk7rCQ
-        Orwwt30Tx5YHFVPizPlyir06Gtb2/HSTYCQ35DEJxVUTBX3QvULS0N9mZlRf0H2V+ofwiLng6EJphF0U
-        hdZSYBkS5BQAszveL6XAge1O5Hz9B5beUvPd/K68rKZLh+7mHuq7dmTsx6MzRRErFZEOcZSnlgLLex7J
-        AjByPpDyQHUGKEsFBRzwXSK4zgJCFriZCG4lg9JUUJkOajKBhAdk/FA/lCzwDzO6sfXFC1vFAAAAAElF
-        TkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABUAAAAYCAIAAACa6yEfAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAABEtJREFUOE+F0ntMWlccB/CzLFmyLFmyLNmatGlVrIJSEAXxCdqapkuTdsuSNV2y
+        7Y/tj63JTJYmpS1b101d69uK+OBxQUFQVJTWR7e5Tl3nA1y0ymzjCx9Ii8rjAhcuWnN3wKtW12Un35Bz
+        zu/74SQE8EAi+N/8VncwuyPQJxUQLgFBlP1XtrZKNjeLg8EiHA8FbuARXoamg+fAgExgKnsn2Jvz0gR+
+        OeW7f9LVmW3v4NvaeDBw47yX7e05CUfKz0HYF78d/Dn738HvZ/m6+I4OHjop2/BYN7BVdKFvVptjbU53
+        GnhwpPgMgIdyganwrRDo4Yeyu+nh+zt5qCETfSQmXliW3u+nldxnujSPIRP5BIAhJOx3zIvBOnnO9gz0
+        sZakBLERQE2K82YZx6pNdXdk7Pif3gx2ZoQM/NwJfi8dM6Q7WlIXtdkrw1Ur4y0zAzX9VTl/ljH/liSt
+        NHJRfRryMQAjCoEp742gIfVAAu0p3lbuujZ5QZE0IU4YLDnRd5v+sJg+JmLOyRNXNRw4VVx4mcc7Uvz6
+        FF8b16VLfqpmwzb0pgqGsZwB8bQ00aZiwxHskN74w+t4O3c7/rZkX2sy2sJd07Ct9YmL+ov2URm6bHIv
+        mcblZyarGBY5C448Og5sKj4CwKTc8/DK28JxNXGeNXLX+m/4Vx+Tv1t4Pen6drySsYCw1jVs+EZAH/Z/
+        1ZMenuGtqynNM1q26bNvYGuk21n9orPGkri5Osa6iuVrTsJb2YoPARhrEBhvvAYPfl0S1vvFptuCPkJm
+        VO8NFdFw795XOG3T+itRg7diZ6vj1+sZmDYBb2Yp3gdgQiUwCl+FB782AdWw19RpC3X0yXKaUXyapOE1
+        oBFCP3w71lJLdzYw9/trr2x7TyNzTclYrKObK2hLQwhJCcLnXpXnxnQKKWOl1GUp3a1iwvJ+r2UGNAyf
+        muFUnliui5+qZD0PYqSGj+sK1LnHHtyMnqqg2uV0r4oBy5AozgFgVguMVwCupsNgDfEuJG65mmr7vZCk
+        BBEMYPKvafrLR4fzKfOiWIcsDta2+4qzAEw17vNwbBFRcbeV1AQx2aeRf3m4+2rEeGH0kpgKHzjoRy6D
+        QH2cH4nxIjR7bazV8BVJw6s573zDpcO/Xj82UUhZEsU4JFRY8ytpkCBnAHiiFYx8AwKKWOhRaYytKtpl
+        7iApQWxtPb/z6bvtQvZ0d35gfe6p7sJq9XFYw+QxkCCnd70sGnq35PhyeSTusJA6vDC3fRPHlgcVU+LM
+        +XKKvToa1vb8dJNgJDfkMQnFVRMFfdC9QtLQ32ZmVF/QfZX6h/CIueDoQmmEXRSF1lJgGRLkFACzO94v
+        pcCB7U7kfP0Hlt5S8938rryspkuH7uYe6rt2ZOzHozNFESsVkQ5xlKeWAst7HskCMHI+kPJAdQYoSwUF
+        HPBdIrjOAkIWuJkIbiWD0lRQmQ5qMoGEB2T8UD+ULPAPM7qx9cULW8UAAAAASUVORK5CYII=
 </value>
   </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAQEAAAAEAIAAoQgAAFgAAACgAAABAAAAAgAAAAAEAIAAAAAAAAEAAACcAAAAnAAAAAAAAAAAA

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/PageObjectDefinitionView.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/PageObjectDefinitionView.cs
@@ -112,6 +112,23 @@ namespace SwdPageRecorder.UI
             }
         }
 
+        internal void DeleteExistingElementFromPage(TreeNode existingNode) {
+
+            var action = (MethodInvoker)delegate
+            {
+                tvWebElements.Nodes[0].Nodes.Remove(existingNode);                
+            };
+
+            if (tvWebElements.InvokeRequired)
+            {
+                tvWebElements.Invoke(action);
+            }
+            else
+            {
+                action();
+            }
+        }
+
         internal void UpdateLastCallStat(string elapsedTime)
         {
             lblLastCallTime.DoInvokeAction(() =>

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/Presenters/PageObjectDefinitionPresenter.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/Presenters/PageObjectDefinitionPresenter.cs
@@ -101,6 +101,27 @@ namespace SwdPageRecorder.UI
             }
         }
 
+        internal void removeElementFromObjectPage(WebElementDefinition element)
+        {
+            if (_isEditingExistingNode)
+            {
+                DialogResult dr = MessageBox.Show("Do you want to remove the element which is named as "+ _currentEditingNode.Text + "?", "Attention", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (dr == DialogResult.Yes)
+                {
+                    view.DeleteExistingElementFromPage(_currentEditingNode);
+                    NotifyOnChanges();
+                }
+                else
+                {
+                    return;
+                }
+            }
+            else
+            {
+                MessageBox.Show("Can not remove if element hasn't been ever saved. ", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+
 
         internal void OpenExistingNodeForEdit(TreeNode treeNode)
         {

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/Presenters/SelectorsEditPresenter.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/Presenters/SelectorsEditPresenter.cs
@@ -74,6 +74,11 @@ namespace SwdPageRecorder.UI
             view.AppendWebElementNameWith("__Copy");
         }
 
+        internal void RemoveWebElement(WebElementDefinition element) 
+        {
+            Presenters.PageObjectDefinitionPresenter.removeElementFromObjectPage(element);
+        }
+
         internal void HighLightWebElement(WebElementDefinition element)
         {
             if (!IsValidForm()) return;
@@ -89,6 +94,7 @@ namespace SwdPageRecorder.UI
             Presenters.PageObjectDefinitionPresenter._currentEditingNode = treeNode;
             var webElementFormData = treeNode.Tag as WebElementDefinition;
             view.UpdateWebElementForm(webElementFormData);
+            view.btnRemoveWebElement.Enabled = true;
         }
 
         internal LocatorSearchMethod GetLocatorSearchMethod()

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.Designer.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.Designer.cs
@@ -28,7 +28,9 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.btnRemoveWebElement = new System.Windows.Forms.Button();
             this.pnlLocatorEditContainer = new System.Windows.Forms.Panel();
             this.txtHtmlElementFrameId = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -64,6 +66,7 @@
             this.btnHighlightWebElementInBrowser = new System.Windows.Forms.Button();
             this.btnNewWebElement = new System.Windows.Forms.Button();
             this.btnUpdateDeclaration = new System.Windows.Forms.Button();
+            this.timer = new System.Windows.Forms.Timer(this.components);
             this.groupBox2.SuspendLayout();
             this.pnlLocatorEditContainer.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -75,6 +78,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox2.BackColor = System.Drawing.SystemColors.Control;
+            this.groupBox2.Controls.Add(this.btnRemoveWebElement);
             this.groupBox2.Controls.Add(this.pnlLocatorEditContainer);
             this.groupBox2.Controls.Add(this.btnReadElementProperties);
             this.groupBox2.Controls.Add(this.btnCopyWebElement);
@@ -87,6 +91,18 @@
             this.groupBox2.TabIndex = 2;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "WebElement";
+            // 
+            // btnRemoveWebElement
+            // 
+            this.btnRemoveWebElement.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRemoveWebElement.Location = new System.Drawing.Point(661, 66);
+            this.btnRemoveWebElement.Name = "btnRemoveWebElement";
+            this.btnRemoveWebElement.Enabled = false;
+            this.btnRemoveWebElement.Size = new System.Drawing.Size(85, 23);
+            this.btnRemoveWebElement.TabIndex = 20;
+            this.btnRemoveWebElement.Text = "Remove";
+            this.btnRemoveWebElement.UseVisualStyleBackColor = true;
+            this.btnRemoveWebElement.Click += new System.EventHandler(this.btnRemoveWebElement_Click);
             // 
             // pnlLocatorEditContainer
             // 
@@ -158,7 +174,7 @@
             this.txtCssSelector.Font = new System.Drawing.Font("Lucida Console", 9.75F);
             this.txtCssSelector.Location = new System.Drawing.Point(135, 57);
             this.txtCssSelector.Name = "txtCssSelector";
-            this.txtCssSelector.Size = new System.Drawing.Size(496, 20);
+            this.txtCssSelector.Size = new System.Drawing.Size(462, 20);
             this.txtCssSelector.TabIndex = 3;
             this.txtCssSelector.Enter += new System.EventHandler(this.txtCssSelector_Enter);
             // 
@@ -166,7 +182,7 @@
             // 
             this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.button2.Enabled = false;
-            this.button2.Location = new System.Drawing.Point(584, 272);
+            this.button2.Location = new System.Drawing.Point(550, 272);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(47, 23);
             this.button2.TabIndex = 20;
@@ -187,7 +203,7 @@
             this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label9.AutoSize = true;
             this.label9.Enabled = false;
-            this.label9.Location = new System.Drawing.Point(332, 255);
+            this.label9.Location = new System.Drawing.Point(298, 255);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(122, 13);
             this.label9.TabIndex = 19;
@@ -208,7 +224,7 @@
             this.textBox7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.textBox7.Enabled = false;
             this.textBox7.Font = new System.Drawing.Font("Lucida Console", 9.75F);
-            this.textBox7.Location = new System.Drawing.Point(335, 275);
+            this.textBox7.Location = new System.Drawing.Point(301, 275);
             this.textBox7.Name = "textBox7";
             this.textBox7.Size = new System.Drawing.Size(238, 20);
             this.textBox7.TabIndex = 12;
@@ -261,7 +277,7 @@
             this.txtOtherLocator.Font = new System.Drawing.Font("Lucida Console", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.txtOtherLocator.Location = new System.Drawing.Point(135, 108);
             this.txtOtherLocator.Name = "txtOtherLocator";
-            this.txtOtherLocator.Size = new System.Drawing.Size(496, 20);
+            this.txtOtherLocator.Size = new System.Drawing.Size(462, 20);
             this.txtOtherLocator.TabIndex = 5;
             this.txtOtherLocator.Enter += new System.EventHandler(this.txtOtherLocator_Enter);
             // 
@@ -281,7 +297,7 @@
             this.txtXPath.Font = new System.Drawing.Font("Lucida Console", 9.75F);
             this.txtXPath.Location = new System.Drawing.Point(135, 80);
             this.txtXPath.Name = "txtXPath";
-            this.txtXPath.Size = new System.Drawing.Size(496, 20);
+            this.txtXPath.Size = new System.Drawing.Size(462, 20);
             this.txtXPath.TabIndex = 4;
             this.txtXPath.Enter += new System.EventHandler(this.txtXPath_Enter);
             // 
@@ -302,7 +318,7 @@
             this.txtHtmlId.Font = new System.Drawing.Font("Lucida Console", 9.75F);
             this.txtHtmlId.Location = new System.Drawing.Point(135, 32);
             this.txtHtmlId.Name = "txtHtmlId";
-            this.txtHtmlId.Size = new System.Drawing.Size(496, 20);
+            this.txtHtmlId.Size = new System.Drawing.Size(462, 20);
             this.txtHtmlId.TabIndex = 2;
             this.txtHtmlId.Enter += new System.EventHandler(this.txtHtmlId_Enter);
             // 
@@ -315,7 +331,7 @@
             this.groupBox1.Controls.Add(this.label4);
             this.groupBox1.Controls.Add(this.txtPropArg1);
             this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Location = new System.Drawing.Point(335, 161);
+            this.groupBox1.Location = new System.Drawing.Point(301, 161);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(302, 91);
             this.groupBox1.TabIndex = 13;
@@ -386,7 +402,7 @@
             this.txtWebElementName.Font = new System.Drawing.Font("Lucida Console", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
             this.txtWebElementName.Location = new System.Drawing.Point(135, 6);
             this.txtWebElementName.Name = "txtWebElementName";
-            this.txtWebElementName.Size = new System.Drawing.Size(496, 20);
+            this.txtWebElementName.Size = new System.Drawing.Size(462, 20);
             this.txtWebElementName.TabIndex = 1;
             // 
             // txtPropHtmlTag
@@ -421,7 +437,7 @@
             // btnReadElementProperties
             // 
             this.btnReadElementProperties.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnReadElementProperties.Location = new System.Drawing.Point(660, 109);
+            this.btnReadElementProperties.Location = new System.Drawing.Point(661, 120);
             this.btnReadElementProperties.Name = "btnReadElementProperties";
             this.btnReadElementProperties.Size = new System.Drawing.Size(85, 23);
             this.btnReadElementProperties.TabIndex = 18;
@@ -443,7 +459,7 @@
             // btnHighlightWebElementInBrowser
             // 
             this.btnHighlightWebElementInBrowser.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnHighlightWebElementInBrowser.Location = new System.Drawing.Point(660, 75);
+            this.btnHighlightWebElementInBrowser.Location = new System.Drawing.Point(661, 92);
             this.btnHighlightWebElementInBrowser.Name = "btnHighlightWebElementInBrowser";
             this.btnHighlightWebElementInBrowser.Size = new System.Drawing.Size(85, 23);
             this.btnHighlightWebElementInBrowser.TabIndex = 15;
@@ -492,6 +508,7 @@
 
         #endregion
 
+        public System.Windows.Forms.Timer timer;
         public System.Windows.Forms.GroupBox groupBox2;
         public System.Windows.Forms.Button btnCopyWebElement;
         public System.Windows.Forms.Button btnHighlightWebElementInBrowser;
@@ -528,5 +545,6 @@
         public System.Windows.Forms.TextBox txtHtmlElementFrameId;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Panel pnlLocatorEditContainer;
+        public System.Windows.Forms.Button btnRemoveWebElement;
     }
 }

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.cs
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.cs
@@ -81,12 +81,25 @@ namespace SwdPageRecorder.UI
 
         private void btnHighlightWebElementInBrowser_Click(object sender, EventArgs e)
         {
+            timer.Interval = 500; // here time in milliseconds
+            timer.Tick += timer_Tick;
+            timer.Start();
+            btnHighlightWebElementInBrowser.Enabled = false;
+
             var element = GetWebElementDefinitionFromForm();
             presenter.HighLightWebElement(element);
+            
+        }
+
+        void timer_Tick(object sender, System.EventArgs e)
+        {
+            btnHighlightWebElementInBrowser.Enabled = true;
+            timer.Stop();
         }
 
         private void btnUpdateDeclaration_Click(object sender, EventArgs e)
         {
+            
             var element = GetWebElementDefinitionFromForm();
             Presenters.PageObjectDefinitionPresenter.UpdatePageDefinition(element);
         }
@@ -97,6 +110,9 @@ namespace SwdPageRecorder.UI
             var element = new WebElementDefinition()
             {
                 Name = txtWebElementName.Text,
+                HtmlId = txtHtmlId.Text,
+                CssSelector = txtCssSelector.Text,
+                Xpath = txtXPath.Text,
                 HowToSearch = GetLocatorSearchMethod(),
                 Locator = GetLocatorText(),
                 
@@ -156,6 +172,7 @@ namespace SwdPageRecorder.UI
 
             chkReturnsListOfWebElements.Checked = false;
 
+            btnRemoveWebElement.Enabled = false;
         }
 
         internal void AppendWebElementNameWith(string appendWithStr)
@@ -231,8 +248,10 @@ namespace SwdPageRecorder.UI
             ClearWebElementForm();
             txtWebElementName.Text = formData.Name;
 
-             // Fill with the formData
-             txtCssSelector.Text = formData.CssSelector;
+            // Fill with the formData
+            txtCssSelector.Text = formData.CssSelector;
+            txtHtmlId.Text = formData.HtmlId;
+            txtXPath.Text = formData.Xpath;
 
 
             switch (formData.HowToSearch)
@@ -283,6 +302,31 @@ namespace SwdPageRecorder.UI
         internal void DisplayWarningMessage(string message)
         {
             MessageBox.Show(message, "Yo! (SWD Page Recorder)", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
+        internal void DisableHighlightWebElementInBrowserButton()
+        {
+            btnHighlightWebElementInBrowser.DoInvokeAction(() =>
+            {
+                btnHighlightWebElementInBrowser.Enabled = false;
+
+            }); 
+        }
+
+        internal void EnableHighlightWebElementInBrowserButton()
+        {
+            btnHighlightWebElementInBrowser.DoInvokeAction(() =>
+            {
+                btnHighlightWebElementInBrowser.Enabled = true;
+
+            });
+        }
+
+        private void btnRemoveWebElement_Click(object sender, EventArgs e)
+        {
+            var element = GetWebElementDefinitionFromForm();
+            presenter.RemoveWebElement(element);
+            presenter.NewWebElement();
         }
     }
 }

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.resx
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdMain/Tabs/SelectorsEditView.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SwdPageRecorder/SwdPageRecorder.UI/SwdPageRecorder.UI.csproj
+++ b/SwdPageRecorder/SwdPageRecorder.UI/SwdPageRecorder.UI.csproj
@@ -114,8 +114,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=2.51.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.51.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.53.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.53.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/SwdPageRecorder/SwdPageRecorder.UI/packages.config
+++ b/SwdPageRecorder/SwdPageRecorder.UI/packages.config
@@ -6,5 +6,5 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
   <package id="RazorEngine" version="3.6.1" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.51.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.53.0" targetFramework="net45" />
 </packages>

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/JavaScript/ElementSearch.js
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/JavaScript/ElementSearch.js
@@ -345,9 +345,10 @@ getElementId = function(element) {
     };
 
     SWD_Page_Recorder.prototype.addElement = function() {
-      var JsonData, XPathLocatorElement, codeIDTextElement;
+      var JsonData, XPathLocatorElement, codeIDTextElement, htmlIdElement;
       hello("addElement");
       codeIDTextElement = document.getElementById("SwdPR_PopUp_CodeIDText");
+      htmlIdElement = document.getElementById("SwdPR_PopUp_ElementId");
       CssSelectorElement = document.getElementById("SwdPR_PopUp_CssSelector");
       XPathLocatorElement = document.getElementById("SwdPR_PopUp_XPathLocator");
       JsonData = {
@@ -355,6 +356,7 @@ getElementId = function(element) {
         "Caller": "addElement",
         "CommandId": pseudoGuid(),
         "ElementCodeName": codeIDTextElement.value,
+        "ElementId": (htmlIdElement.hasChildNodes())?htmlIdElement.firstChild.nodeValue:"",
         "ElementCssSelector": CssSelectorElement.firstChild.nodeValue,
         "ElementXPath": XPathLocatorElement.firstChild.nodeValue
       };

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/JsCommand/AddElement.cs
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/JsCommand/AddElement.cs
@@ -7,6 +7,7 @@ namespace SwdPageRecorder.WebDriver.JsCommand
 {
     public class AddElement : BrowserCommand
     {
+        public string ElementId { get; set; }
         public string ElementCodeName {get; set;}
         public string ElementXPath { get; set; }
         public string ElementCssSelector { get; set; }

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/SwdPageRecorder.WebDriver.csproj
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/SwdPageRecorder.WebDriver.csproj
@@ -78,8 +78,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WebDriver, Version=2.51.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.51.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.53.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.53.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/WebElementDefinition.cs
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/WebElementDefinition.cs
@@ -23,6 +23,12 @@ namespace SwdPageRecorder.WebDriver
         [DisplayName("Locator")]
         public string Locator { get; set; }
 
+        [DisplayName("Id")]
+        public string HtmlId { get; set; }
+
+        [DisplayName("Xpath")]
+        public string Xpath { get; set; }
+
         [Browsable(false)]
         public string HtmlTag { get; set; }
 
@@ -88,13 +94,32 @@ namespace SwdPageRecorder.WebDriver
             }
         }
 
+        [Browsable(false)]
+        [XmlIgnore]
+        public string HtmlClass 
+        {
+            get
+            {
+                var htmlClass = string.Empty;
+
+                if (AllHtmlTagProperties.ContainsKey("class"))
+                {
+                    htmlClass = AllHtmlTagProperties["class"];
+                }
+
+                return htmlClass;
+            }
+        }
+
         public WebElementDefinition Clone()
         {
             var clone =  new WebElementDefinition()
             {
                 Name = Name,
+                HtmlId = HtmlId,
                 Locator = Locator,
                 CssSelector = CssSelector,
+                Xpath = Xpath,
                 HowToSearch = HowToSearch,
                 HtmlTag = HtmlTag,
                 ReturnsCollection = ReturnsCollection,

--- a/SwdPageRecorder/SwdPageRecorder.WebDriver/packages.config
+++ b/SwdPageRecorder/SwdPageRecorder.WebDriver/packages.config
@@ -3,5 +3,5 @@
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="2.51.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="2.53.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Privet Dmitry,
First of all bol'shoe spasibo for this tool. It's such a big time saver.
I've polished some minor things in the tool. You can take a look and maybe even merge it with the main repository.

Here are the key changes I have applied:
- elements' ids are passed from the browser to the SWD capturing tool (updated ElementSearch.js)
- Updating one type of locator doesn't erase values for other locator types. For example if you choose to use id selector as default method to locate your element then xpath and css values are still kept in case if you wish to go back to one of these locator types later in a future.
- Disabling Highlight Element button for half a second after it was clicked on. This prevents double clicking and restores properly original css value for the element.
- Added Remove button to remove an element from Page Object.
- Added "HtmlClass" property into WebElementDefinition.cs. It helps to write more customizable templates which take into account not just type of an element but also its css class value.
- Updated Selenium Library to 2.53

Please, feel free to express any comments or concerns if you have with my modification. 
By the way, you can write in Russian back to me :-) It's just at work I don't have Russian keyboard.

Thanks,
George Kapustin.
